### PR TITLE
Allow context override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "execli",
   "description": "Genenerate task-oriented CLIs declaratively",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "keywords": [
     "cli",
     "task",

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -215,7 +215,7 @@ const createContextHolder = <C>(
 
   const contextHolder: ContextHolder<C> = {
     add(addedContext) {
-      context = { ...addedContext, ...context };
+      context = { ...context, ...addedContext };
     },
     copy() {
       return createContextHolder(context);


### PR DESCRIPTION
It can be useful to asynchronously give default values to options.