### PR TITLE
Export `ExecError`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Command, getCommand, OptionsContext } from "./commands.js";
 export { Context } from "./context.js";
-export { Exec } from "./exec.js";
+export { Exec, ExecError } from "./exec.js";
 export { Task } from "./tasks.js";


### PR DESCRIPTION
This can be useful in case of error to inspect the command outputs.